### PR TITLE
Update Dutch translation according to language rules

### DIFF
--- a/src/nl/validation.php
+++ b/src/nl/validation.php
@@ -138,7 +138,7 @@ return [
         'month'                 => 'maand',
         'name'                  => 'naam',
         'password'              => 'wachtwoord',
-        'password_confirmation' => 'wachtwoord bevestiging',
+        'password_confirmation' => 'wachtwoordbevestiging',
         'phone'                 => 'telefoonnummer',
         'second'                => 'seconde',
         'sex'                   => 'geslacht',


### PR DESCRIPTION
Fixed a typo (actual a language rule error) in the Dutch translations. The rules are explained at http://www.spatiegebruik.nl/regels.html :)
